### PR TITLE
bugfix: corrected sorting when have a submenu and adds a new item

### DIFF
--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -2,6 +2,7 @@
 
 namespace Harimayco\Menu\Controllers;
 
+use Harimayco\Menu\Facades\Menu;
 use Illuminate\Http\Request;
 use App\Http\Requests;
 use App\Http\Controllers\Controller;
@@ -69,6 +70,7 @@ class MenuController extends Controller
         $menuitem->label = request()->input("labelmenu");
         $menuitem->link = request()->input("linkmenu");
         $menuitem->menu = request()->input("idmenu");
+        $menuitem->sort = MenuItems::getNextSortRoot(request()->input("idmenu"));
         $menuitem->save();
 
     }

--- a/src/Models/MenuItems.php
+++ b/src/Models/MenuItems.php
@@ -18,6 +18,11 @@ class MenuItems extends Model
 		return $this -> where("parent", $id) -> get();
 	}
 	public function getall($id) {
-		return $this -> where("menu", $id) -> orderBy("sort", "asc") -> get();
+		return $this -> where("menu", $id) -> orderBy("sort", "asc")->get();
 	}
+
+	public static function getNextSortRoot($menu){
+        return self::where('menu',$menu)->where('depth',0)->max('sort') + 1;
+    }
+
 }


### PR DESCRIPTION
When you add an item to a menu that it have a submenu on the first item the parent became the new element. 